### PR TITLE
Do not call Globalize.parseFloat if the value is not a string.

### DIFF
--- a/jquery.validate.globalize.js
+++ b/jquery.validate.globalize.js
@@ -11,11 +11,16 @@
         max: $.validator.methods.max,
         range: $.validator.methods.range
     };
+		
+    var parseFloat = function(value) {
+      return Object.prototype.toString.call(value) == '[object String]' ?
+      Globalize.parseFloat(value) : '';
+    };
 
     // Tell the validator that we want numbers parsed using Globalize
 
     $.validator.methods.number = function (value, element) {
-        var val = Globalize.parseFloat(value);
+        var val = parseFloat(value);
         return this.optional(element) || ($.isNumeric(val));
     };
 
@@ -30,17 +35,17 @@
     // then call into original implementation with parsed value
 
     $.validator.methods.min = function (value, element, param) {
-        var val = Globalize.parseFloat(value);
+        var val = parseFloat(value);
         return originalMethods.min.call(this, val, element, param);
     };
 
     $.validator.methods.max = function (value, element, param) {
-        var val = Globalize.parseFloat(value);
+        var val = parseFloat(value);
         return originalMethods.max.call(this, val, element, param);
     };
 
     $.validator.methods.range = function (value, element, param) {
-        var val = Globalize.parseFloat(value);
+        var val = parseFloat(value);
         return originalMethods.range.call(this, val, element, param);
     };
 


### PR DESCRIPTION
When a input is of type number (instead of text) :
    <input type="number" .... />
and that the user entered some letters, then jquery.validate uses false for the value of the input, and not the real string or a empty string.

This is done in the elementValue function :
```
elementValue: function( element ) {
  ...
  else if ( type === "number" && typeof element.validity !== "undefined" ) {
    return element.validity.badInput ? false : $element.val();
  }
  ...
```

In this case all the validation functions of jquery.validate.globalize working for numeric will fail as it call Globalize.parseFloat with a boolean parameter.
It is the case for the number, min, max, range functions.

In this function, instead of calling directly Globalize.parseFloat, I call a local function parseFloat that returns Globalize.parseFloat if the value is a string, otherwise an empty string.